### PR TITLE
Allow id attributes for textbox and select elements

### DIFF
--- a/lib/getSelect.js
+++ b/lib/getSelect.js
@@ -32,7 +32,8 @@ function getSelect(opts) {
       value: opts.value,
       disabled: opts.disabled,
       className: className,
-      multiple: opts.multiple
+      multiple: opts.multiple,
+      id: opts.id
     },
     children: opts.options,
     events: {

--- a/lib/getTextbox.js
+++ b/lib/getTextbox.js
@@ -38,7 +38,8 @@ function getTextbox(opts) {
       disabled: opts.disabled,
       placeholder: opts.placeholder,
       readOnly: opts.readOnly,
-      className: className
+      className: className,
+      id: opts.id
     },
     events: {
       change: opts.onChange


### PR DESCRIPTION
To be used together with the label's htmlFor attribute.
